### PR TITLE
Allow user to pass just the video ID. (Full URL still works.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Read Youtube transcript (captions) from any public Youtube video
 PhantomJS http://phantomjs.org/download.html
 
 ####Usage
+Start PhantomJS
+```bash
+bin/phantomjs --webdriver=9999
+```
+Run script
 ```bash
 ruby yt_captions.rb http://www.youtube.com/watch?v=[video-id]
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ bin/phantomjs --webdriver=9999
 Run script
 ```bash
 ruby yt_captions.rb http://www.youtube.com/watch?v=[video-id]
+ruby yt_captions.rb [video-id]
 ```
 Where `[video-id]` is the Youtube video ID.
 

--- a/yt_captions.rb
+++ b/yt_captions.rb
@@ -10,9 +10,10 @@ wait = Selenium::WebDriver::Wait.new(:timeout => 10) # seconds
 
 driver.navigate.to link
 
-wait.until { driver.find_element(:class => 'yt-uix-button-icon-action-panel-transcript') }
+overflow_button = driver.find_element(:id, 'action-panel-overflow-button')
+overflow_button.click
 
-transcript_button = driver.find_element(:class, 'yt-uix-button-icon-action-panel-transcript')
+transcript_button = driver.find_element(:class, 'action-panel-trigger-transcript')
 transcript_button.click
 
 # wait for at least one transcript line

--- a/yt_captions.rb
+++ b/yt_captions.rb
@@ -1,8 +1,14 @@
 require 'selenium-webdriver'
 require 'nokogiri'
+require 'uri'
 
-# supply full YouTube URL from command line
-link = ARGV[0]
+# supply video ID or full YouTube URL from command line
+arg = ARGV[0]
+if arg =~ /^#{URI::regexp}$/
+  link = arg
+else
+  link = "http://www.youtube.com/watch?v=#{arg}"
+end
 
 # PhantomJS server
 driver = Selenium::WebDriver.for(:remote, :url => "http://localhost:9999")


### PR DESCRIPTION
You can call the script as either `ruby yt_captions.rb http://www.youtube.com/watch?v=[video-id]` or `ruby yt_captions.rb [video-id]`